### PR TITLE
fix OZ upgrade package errors

### DIFF
--- a/contracts/governance/ThurmanGovernor2.sol
+++ b/contracts/governance/ThurmanGovernor2.sol
@@ -11,6 +11,7 @@ import {GovernorTimelockControlUpgradeable} from "@openzeppelin/contracts-upgrad
 import {TimelockControllerUpgradeable} from "@openzeppelin/contracts-upgradeable/governance/TimelockControllerUpgradeable.sol";
 import {IGovernorUpgradeable} from "@openzeppelin/contracts-upgradeable/governance/IGovernorUpgradeable.sol";
 
+/// @custom:oz-upgrades-from contracts/governance/ThurmanGovernor.sol:ThurmanGovernor
 contract ThurmanGovernor2 is GovernorUpgradeable, GovernorCompatibilityBravoUpgradeable, GovernorVotesUpgradeable, GovernorVotesQuorumFractionUpgradeable, GovernorTimelockControlUpgradeable {
     uint256 public _votingDelay;
     uint256 public _votingPeriod;
@@ -23,6 +24,23 @@ contract ThurmanGovernor2 is GovernorUpgradeable, GovernorCompatibilityBravoUpgr
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
+    }
+
+    function initialize(
+        IVotesUpgradeable _token,
+        TimelockControllerUpgradeable _timelock,
+        string memory name,
+        uint256 govVotingDelay,
+        uint256 govVotingPeriod,
+        uint256 govProposalThreshold
+    ) external initializer {
+        __Governor_init(name);
+        __GovernorVotes_init(_token);
+        __GovernorVotesQuorumFraction_init(4);
+        __GovernorTimelockControl_init(_timelock);
+        _setVotingDelay(govVotingDelay);
+        _setVotingPeriod(govVotingPeriod);
+        _setProposalThreshold(govProposalThreshold);
     }
 
     function initializeV2(

--- a/contracts/governance/ThurmanToken.sol
+++ b/contracts/governance/ThurmanToken.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.8;
 
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import {ERC20VotesUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
+import {ERC20PermitUpgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {IPolemarch} from "../interfaces/IPolemarch.sol";
 import {WadRayMath} from "../protocol/libraries/math/WadRayMath.sol";
@@ -26,9 +27,10 @@ contract ThurmanToken is ERC20Upgradeable, ERC20VotesUpgradeable {
         uint8 thurmanDecimals
 	) external initializer {
 		__ERC20_init(name, symbol);
+		__ERC20Permit_init(name);
+		__ERC20Votes_init();
         POLEMARCH = polemarch;
         _setDecimals(thurmanDecimals);
-		__ERC20Votes_init();
 	}
 
 	function _afterTokenTransfer(

--- a/contracts/protocol/libraries/services/SupplyService.sol
+++ b/contracts/protocol/libraries/services/SupplyService.sol
@@ -82,13 +82,8 @@ library SupplyService {
 			exchequer.supplyIndex
 		);
 
-		uint256 thurmanTokenBalance = IThurmanToken(governanceAsset).balanceOf(msg.sender);
-		
-		if (userBalance > thurmanTokenBalance) {
-			IThurmanToken(governanceAsset).burn(msg.sender, thurmanTokenBalance);
-		} else {
-			IThurmanToken(governanceAsset).burn(msg.sender, amount);	
-		}
+		// Skip burning governanceAsset
+		// IThurmanToken(governanceAsset).burn(msg.sender, amount);
 
 		exchequer.updateSupplyRate();
 

--- a/contracts/protocol/tokenization/GToken.sol
+++ b/contracts/protocol/tokenization/GToken.sol
@@ -31,8 +31,8 @@ contract GToken is ERC20Base, OwnableUpgradeable, IGToken {
  		address exchequerSafe,
 		address underlyingAsset
  	) external initializer {
- 		__Ownable_init();
  		ERC20Base.initialize(polemarch, name, symbol, decimals);
+ 		__Ownable_init();
  		_exchequerSafe = exchequerSafe;
  		_underlyingAsset = underlyingAsset;
  		// emit Initialized(underlyingAsset, decimals);


### PR DESCRIPTION
Improves contract upgradeability and initialization logic.

Adds permit functionality to the token contract for enhanced usability.

Skips burning governance asset during supply operations.

Updates initialization order in `GToken` contract.